### PR TITLE
[11.0][mrp_mto_with_stock] Migration

### DIFF
--- a/mrp_mto_with_stock/models/mrp_production.py
+++ b/mrp_mto_with_stock/models/mrp_production.py
@@ -4,6 +4,7 @@
 
 from odoo import api, models
 from odoo.exceptions import UserError
+import copy
 import logging
 _logger = logging.getLogger(__name__)
 
@@ -25,60 +26,57 @@ class MrpProduction(models.Model):
         res = super(MrpProduction, self).action_assign()
         # try to create procurements:
         move_obj = self.env['stock.move']
-        procurement_obj = self.env['procurement.group']
         for production in self:
             warehouse = production.location_src_id.get_warehouse()
             mto_with_no_move_dest_id = warehouse.mrp_mto_mts_forecast_qty
-            for move in self.move_raw_ids:
-                group = new_move = procurement = False
+            move_ids = copy.copy(self.move_raw_ids.ids)
+            for move in move_obj.browse(move_ids):
+                new_move = False
                 qty_to_procure = 0.0
                 if move.state in ('partially_available', 'confirmed') \
                         and move.location_id in \
                         move.product_id.mrp_mts_mto_location_ids \
                         and not mto_with_no_move_dest_id:
-                    # Search procurement group which has created from here
-                    group_name = '{0}:{1}'.format(
-                        production.name, move.product_id.name)
-                    procurement = procurement_obj.search(
-                        [('name', '=', group_name)])
-                    if not procurement:
-                        # We have to split the move because we can't have
-                        # a part of the move that have ancestors and not the
-                        # other else it won't ever be reserved.
-                        qty_to_procure = (
-                            move.product_uom_qty - move.reserved_availability)
-                        if qty_to_procure < move.product_uom_qty:
-                            move._do_unreserve()
-                            new_move_id = move._split(
-                                qty_to_procure,
-                                restrict_partner_id=move.restrict_partner_id)
-                            new_move = move_obj.browse(new_move_id)
-                            move._action_assign()
-                        else:
-                            new_move = move
-                        pg_data = production._get_procurement_group_data(
-                            new_move)
-                        group = procurement_obj.create(pg_data)
-                if move.state in ('partially_available', 'confirmed') \
+                    # We have to split the move because we can't have
+                    # a part of the move that have ancestors and not the
+                    # other else it won't ever be reserved.
+                    qty_to_procure = (
+                        move.product_uom_qty - move.reserved_availability)
+                    if qty_to_procure < move.product_uom_qty:
+                        move._do_unreserve()
+                        new_move_id = move._split(
+                            qty_to_procure,
+                            restrict_partner_id=move.restrict_partner_id)
+                        new_move = move_obj.browse(new_move_id)
+                        move._action_assign()
+                    else:
+                        new_move = move
+                elif move.state in ('partially_available', 'confirmed') \
                         and move.procure_method == 'make_to_stock' \
                         and mto_with_no_move_dest_id and \
                         move.location_id in \
                         move.product_id.mrp_mts_mto_location_ids:
                     qty_to_procure = production.get_mto_qty_to_procure(move)
                     if qty_to_procure > 0.0:
-                        pg_data = production._get_procurement_group_data(move)
-                        group = procurement_obj.create(pg_data)
                         new_move = move
-                if group:
-                    production.run_procurement(new_move, group, qty_to_procure)
+                    else:
+                        continue
+                if new_move:
+                    production.run_procurement(new_move, qty_to_procure,
+                                               mto_with_no_move_dest_id)
         return res
 
     @api.multi
-    def run_procurement(self, move, group, qty):
+    def run_procurement(self, move, qty, mto_with_no_move_dest_id):
         self.ensure_one()
         errors = []
         values = move._prepare_procurement_values()
-        origin = ((group and group.name + ":") or "") + 'MTO -> Production'
+        # In that mode, we don't want any link between the raw material move
+        # And the previous move generated now.
+        if mto_with_no_move_dest_id:
+            values.pop('move_dest_ids', None)
+        origin = '{0}:{1}'.format(self.name, move.product_id.name) + \
+                 ':MTO -> Production'
         values['route_ids'] = move.product_id.route_ids
         try:
             self.env['procurement.group'].run(

--- a/mrp_mto_with_stock/tests/test_mrp_mto_with_stock.py
+++ b/mrp_mto_with_stock/tests/test_mrp_mto_with_stock.py
@@ -91,7 +91,7 @@ class TestMrpMtoWithStock(TransactionCase):
         # We check if first MO is able to assign it self even if it has
         # previously generate procurements, it would not be the case in the
         # other mode (without mrp_mto_mts_reservable_stock on warehouse)
-        self.assertEquals(self.production.availability, 'partially_available')
+        self.assertEquals(self.production.availability, 'assigned')
 
         self.assertEquals(self.subproduct1.virtual_available, 0)
 


### PR DESCRIPTION
Hello,

This PR aims to fix the issues I talked about in this PR : https://github.com/OCA/manufacture/pull/255
I have put back a test that was removed from version 10, which is useful to test the mto_with_no_move_dest_id which does not work for now. (Fixed here)

I also removed the procurement group creation logic which does not seem necessary anymore.
Let me know what you think,
Thanks