### PR TITLE
[FIX] mrp_account_analytic_wip: capture actuals for MO materials and operations

### DIFF
--- a/mrp_account_analytic_wip/models/mrp_workorder.py
+++ b/mrp_account_analytic_wip/models/mrp_workorder.py
@@ -30,5 +30,16 @@ class MrpWorkcenterProductivity(models.Model):
 
     def _prepare_mrp_workorder_analytic_item(self):
         values = super()._prepare_mrp_workorder_analytic_item()
-        values["product_id"] = self.workcenter_id.analytic_product_id.id
+        # Ensure the related Tracking Item is populated
+        workorder = self.workorder_id
+        if not workorder.analytic_tracking_item_id:
+            item_vals = {
+                "product_id": workorder.workcenter_id.analytic_product_id.id,
+                "production_id": workorder.production_id.id,
+                "workcenter_id": workorder.workcenter_id.id,
+            }
+            item = workorder.production_id._get_matching_tracking_item(item_vals)
+            self.workorder_id.analytic_tracking_item_id = item
+        values["analytic_tracking_item_id"] = workorder.analytic_tracking_item_id.id
+        values["product_id"] = workorder.workcenter_id.analytic_product_id.id
         return values

--- a/mrp_account_analytic_wip/models/stock_move.py
+++ b/mrp_account_analytic_wip/models/stock_move.py
@@ -56,65 +56,37 @@ class StockMove(models.Model):
                 move.should_consume_qty = 0
         return res
 
-    # Copy Tracking item, so that when a move is split,
-    # it still related to the same Tracking Item
+    # Store related Tracking Item, for computation efficiency
     analytic_tracking_item_id = fields.Many2one(
-        "account.analytic.tracking.item", string="Tracking Item", copy=True
+        "account.analytic.tracking.item",
+        string="Tracking Item",
+        copy=True
+        # Copy Tracking item, so that when a move is split,
+        # it still related to the same Tracking Item
     )
 
     def _prepare_mrp_raw_material_analytic_line(self):
         values = super()._prepare_mrp_raw_material_analytic_line()
+        # Ensure the related Tracking Item is populated
+        if not self.analytic_tracking_item_id:
+            item_vals = {
+                "production_id": values.get("manufacturing_order_id"),
+                "product_id": values.get("product_id"),
+            }
+            item = self.raw_material_production_id._get_matching_tracking_item(
+                item_vals
+            )
+            self.analytic_tracking_item_id = item
         values["analytic_tracking_item_id"] = self.analytic_tracking_item_id.id
         return values
-
-    def _prepare_tracking_item_values(self):
-        analytic = self.raw_material_production_id.analytic_account_id
-        return {
-            "analytic_id": analytic.id,
-            "product_id": self.product_id.id,
-            "stock_move_id": self.id,
-            "requested_qty": self.product_uom_qty,
-        }
-
-    def populate_tracking_items(self):
-        """
-        When creating an Analytic Item,
-        link it to a Tracking Item, the may have to be created if it doesn't exist.
-        """
-        TrackingItem = self.env["account.analytic.tracking.item"]
-        to_populate = self.filtered(
-            lambda x: x.raw_material_production_id.analytic_account_id
-            and x.raw_material_production_id.state not in ("draft", "done", "cancel")
-        )
-        production_id = to_populate.raw_material_production_id
-        if production_id.is_post_wip_automatic:
-            production_id.action_post_inventory_wip()
-        all_tracking = production_id.analytic_tracking_item_ids
-        for item in to_populate:
-            tracking = all_tracking.filtered(
-                lambda x: x.product_id == item.product_id  # and x.stock_move_id
-            )
-            vals = item._prepare_tracking_item_values()
-            if tracking:
-                tracking.write(vals)
-            else:
-                tracking = TrackingItem.create(vals)
-            item.analytic_tracking_item_id = tracking
 
     @api.model
     def create(self, vals):
         new_moves = super().create(vals)
-        new_moves.populate_tracking_items()
+        new_moves.raw_material_production_id.populate_ref_bom_tracking_items()
         return new_moves
 
     def write(self, vals):
         res = super().write(vals)
-        if not self.env.context.get("flag_write_tracking"):
-            moves = self.filtered(
-                lambda x: x.raw_material_production_id.analytic_account_id
-                and not x.analytic_tracking_item_id
-            )
-            moves and moves.with_context(
-                flag_write_tracking=True
-            ).populate_tracking_items()
+        self.raw_material_production_id.populate_ref_bom_tracking_items()
         return res


### PR DESCRIPTION
DEPENDS ON https://github.com/ursais/account-analytic/pull/7

- [FIX] mrp_account_analytic_wip: capture actuals for MO materials and operations

Refactor Tracking Item population, to be based on:
- Components: Product instead of Stock Move
- Operations: Work Center instead of Work Order

Also:

-  [IMP] mrp_account_analytic_wip: compute Atual Amount using current cost

Instead of using historic cost stored in Analytic items.
Cost change on Products should trigger recalculation of Actuals in
running MOs.