### PR TITLE
[FIX] mrp_account_analytic_wip: automatic WIP post on consumption, and on reference BOM change

### DIFF
--- a/mrp_account_analytic_wip/models/mrp_bom.py
+++ b/mrp_account_analytic_wip/models/mrp_bom.py
@@ -59,7 +59,10 @@ class MrpBom(models.Model):
                 ("analytic_account_id", "!=", False),
             ],
         )
+        # Update Tracking Items, for possible new lines and standard amount changes
         productions.populate_ref_bom_tracking_items()
+        # Post WIP based on the changes
+        productions.filtered("is_post_wip_automatic").action_post_inventory_wip()
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/mrp_account_analytic_wip/models/mrp_workorder.py
+++ b/mrp_account_analytic_wip/models/mrp_workorder.py
@@ -43,3 +43,10 @@ class MrpWorkcenterProductivity(models.Model):
         values["analytic_tracking_item_id"] = workorder.analytic_tracking_item_id.id
         values["product_id"] = workorder.workcenter_id.analytic_product_id.id
         return values
+
+    def generate_mrp_work_analytic_line(self):
+        res = super().generate_mrp_work_analytic_line()
+        # When recording actuals, consider posting WIp immedately
+        mos_to_post = self.production_id.filtered("is_post_wip_automatic")
+        mos_to_post.action_post_inventory_wip()
+        return res

--- a/mrp_account_analytic_wip/models/stock_move.py
+++ b/mrp_account_analytic_wip/models/stock_move.py
@@ -80,6 +80,13 @@ class StockMove(models.Model):
         values["analytic_tracking_item_id"] = self.analytic_tracking_item_id.id
         return values
 
+    def generate_mrp_raw_analytic_line(self):
+        res = super().generate_mrp_raw_analytic_line()
+        # When recording actuals, consider posting WIP immediately
+        mos_to_post = self.raw_material_production_id.filtered("is_post_wip_automatic")
+        mos_to_post.action_post_inventory_wip()
+        return res
+
     @api.model
     def create(self, vals):
         new_moves = super().create(vals)


### PR DESCRIPTION
- [FIX] Adjust tracking item name for operations lines.
- [IMP] mrp_account_analytic_wip: Update Tracking Items based on the Reference BoM
- [IMP] mrp_account_analytic_wip: on Reference BOM change, update impacted MOs
- [FIX] mrp_account_analytic_wip: capture actuals for MO materials and operations
- [IMP] mrp_account_analytic_wip: compute Atual Amount using current cost
- [FIX] mrp_account_analytic_wip: automatic WIP post on consumption, and on reference BOM change
