### PR TITLE
mrp_account_analytic: Fix processing workorder without analytic

### DIFF
--- a/mrp_account_analytic/models/mrp_workorder.py
+++ b/mrp_account_analytic/models/mrp_workorder.py
@@ -28,6 +28,8 @@ class MrpWorkcenterProductivity(models.Model):
     def generate_mrp_work_analytic_line(self):
         AnalyticLine = self.env["account.analytic.line"].sudo()
         for timelog in self:
+            if not timelog.production_id.analytic_account_id:
+                continue
             line_vals = timelog._prepare_mrp_workorder_analytic_item()
             analytic_line = AnalyticLine.create(line_vals)
             analytic_line.on_change_unit_amount()

--- a/mrp_account_analytic/models/stock_move.py
+++ b/mrp_account_analytic/models/stock_move.py
@@ -35,7 +35,9 @@ class StockMove(models.Model):
         """
         AnalyticLine = self.env["account.analytic.line"].sudo()
         existing_items = AnalyticLine.search([("stock_move_id", "in", self.ids)])
-        for move in self.filtered("raw_material_production_id.analytic_account_id"):
+        for move in self:
+            if not move.raw_material_production_id.analytic_account_id:
+                continue
             line_vals = move._prepare_mrp_raw_material_analytic_line()
             if move in existing_items.mapped("stock_move_id"):
                 analytic_line = existing_items.filtered(

--- a/mrp_account_analytic/tests/test_mrp_analytic.py
+++ b/mrp_account_analytic/tests/test_mrp_analytic.py
@@ -119,3 +119,17 @@ class TestMRP(common.TransactionCase):
         self.assertEqual(
             analytic_amount, -14.00, "Expected Analytic Items total amount"
         )
+
+    def test_120_no_analytic(self):
+        mo_create_form = Form(self.env["mrp.production"])
+        mo_create_form.product_id = self.product_lemonade
+        mo_create_form.bom_id = self.mrp_bom_lemonade
+        mo_create_form.product_qty = 1
+        mo_lemonade = mo_create_form.save()
+        mo_lemonade.action_confirm()
+        workorder = mo_lemonade.workorder_ids
+        workorder.button_start()
+        workorder.button_finish()
+        self.assertEqual(workorder.state, "done")
+        mo_lemonade.button_mark_done()
+        self.assertEqual(mo_lemonade.state, "done")


### PR DESCRIPTION
In case analytic account is not defined on the manufacturing order, no analytic entries must be generated through the processing of workorders.